### PR TITLE
🔒 Fix reverse tabnabbing vulnerability in social.html

### DIFF
--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,7 +1,7 @@
 <ul class="social-media-list">
 {%- for entry in site.minima.social_links -%}
   <li>
-    <a rel="me" href="{{ entry.url }}" target="_blank" title="{{ entry.title }}">
+    <a rel="me noopener noreferrer" href="{{ entry.url }}" target="_blank" title="{{ entry.title }}">
       <span class="grey fa-brands fa-{{ entry.icon }} fa-lg"></span>
     </a>
   </li>


### PR DESCRIPTION
🎯 **What:** Fixed a reverse tabnabbing vulnerability in `_includes/social.html` by appending `noopener noreferrer` to the `rel` attribute of social media anchor links that use `target="_blank"`.

⚠️ **Risk:** Without `noopener noreferrer`, when a user clicked a social media link and it opened in a new tab, the newly opened page would have access to the `window.opener` object. This object could have been used by a malicious page (or an untrusted script on the target page) to maliciously redirect the user's original referring tab, which is a reverse tabnabbing risk. 

🛡️ **Solution:** Added `noopener noreferrer` to the `rel` attribute of the affected anchor tags, safely preserving the original `rel="me"`. I also scanned the repository using `grep` for other occurrences of `target="_blank"` and found `_includes/share.html`, but it already correctly included `rel="noopener noreferrer"`. Tests and site builds were confirmed to pass locally.

---
*PR created automatically by Jules for task [18147369036786890761](https://jules.google.com/task/18147369036786890761) started by @hodovani*