### PR TITLE
Render LaTeX formulas with MathJax 3

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,5 +11,6 @@
   {%- endif -%}
 
   {%- include custom-head.html -%}
+  {%- include mathjax.html -%}
   
 </head>

--- a/_includes/mathjax.html
+++ b/_includes/mathjax.html
@@ -1,0 +1,16 @@
+{%- if page.layout == "post" -%}
+<!-- MathJax 3 support for LaTeX formulas -->
+<script>
+  window.MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']],
+      processEscapes: true
+    },
+    options: {
+      skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+    }
+  };
+</script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+{%- endif -%}


### PR DESCRIPTION
This PR integrates MathJax 3 to properly render mathematical expressions in posts, supporting both standard inline/block delimiters ($...$ and $$...$$) and Kramdown compiled math delimiters (\(...\\) and \[...\]). MathJax 3 is configured to load asynchronously on all posts automatically.

---
*PR created automatically by Jules for task [16635535011384213533](https://jules.google.com/task/16635535011384213533) started by @hodovani*